### PR TITLE
more concise path to source uberjar, :artifact-name option

### DIFF
--- a/src/leiningen/init_script.clj
+++ b/src/leiningen/init_script.clj
@@ -25,7 +25,7 @@
 (def clean-template (slurp (resource-input-stream "clean-template")))
 
 (defn gen-init-script [project opts]
-  (let [name (:name project)
+  (let [name (or (:artifact-name opts) (:name project))
         version (:version project)
         description (:description project)
         pid-dir (:pid-dir opts)
@@ -45,7 +45,7 @@
 (defn gen-install-script [uberjar-path init-script-path opts]
   (let [jar-install-dir (:jar-install-dir opts)
         init-script-install-dir (:init-script-install-dir opts)
-        name (:name opts)
+        name (or (:artifact-name opts) (:name opts))
         version (:version opts)
         installed-init-script-path (str init-script-install-dir "/" name "d")]
     (format install-template
@@ -60,7 +60,7 @@
 (defn gen-clean-script [project opts]
   (let [jar-install-dir (:jar-install-dir opts)
         init-script-install-dir (:init-script-install-dir opts)
-        name (:name project)]
+        name (or (:artifact-name opts) (:name project))]
     (format clean-template name jar-install-dir init-script-install-dir)))
 
 (defn create-output-dir [path]


### PR DESCRIPTION
When using lein-init-script with profiles, the `:target-path` provides a more direct path to the generated jars; however, I've found that various different versions of leiningen generate the uberjar in different directories. I added a little mechanism to check in the three places that I've seen uberjars end up [here](https://github.com/jalehman/lein-init-script/commit/9dfd222668e1fe9b15bd3d1c6125cb9b8da1475e#diff-90fbaf6abb9188658d62b0a64dd0c184R87).

Also, I found myself wanting to create multiple init-scripts from the same repository with different names. I added a `:artifact-name` option that renames the copied artifact and scripts. 
