### PR TITLE
Disable uberjar fix #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ which are passed to the the init-script task by adding a :lis-opts entry to the 
 
 Create a main class for your project, run <code>lein init-script</code>, and check the ./init-script directory. Typically you'll want to run <code>./init-script/install-project</code> and then restart with e.g. <code>/etc/init.d/projectd restart</code>.
 
+### ring uberjar and others
+
+If you're using `ring uberjar` you can disable running vanilla `uberjar` by `init-script`. To do this set `:run-uberjar?` to false and run arbitrary `xxx uberjar` before calling init-script. To do it in one like use `do` task:
+
+```bash
+lein do ring uberjar, init-script
+```
+
 ## Limitations
 
 No Windows support at this time, if you'd like to see support for windows services, please open up an issue.

--- a/src/leiningen/init_script.clj
+++ b/src/leiningen/init_script.clj
@@ -82,6 +82,7 @@
      :init-script-install-dir "/etc/init.d"
      :artifact-dir (str root "/init-script")
      :redirect-output-to "/dev/null"
+     :run-uberjar? true
      :version version}))
 
 (defn- get-source-uberjar-path
@@ -105,13 +106,16 @@
         name (or (:artifact-name opts) (:name opts))
         version (:version opts)
         artifact-dir (:artifact-dir opts) ;; the init-script dir
+        run-uberjar? (:run-uberjar? opts)
         source-uberjar-path (get-source-uberjar-path project opts)
         artifact-uberjar-path (format "%s/%s-%s-standalone.jar" artifact-dir name version)
         artifact-init-script-path (str artifact-dir "/" name "d")
         install-script-path (str artifact-dir "/" "install-" name)
         clean-script-path (str artifact-dir "/" "clean-" name)]
     (create-output-dir artifact-dir) ;; Creates directory for init-scripts
-    (uberjar project) ;; Leiningen task that creates uberjars
+    (when run-uberjar?
+      (uberjar project)) ;; Leiningen task that creates uberjars
+
     ;; Copy from source dir (where uberjars have been created by leiningen) to artifact-path
     (io/copy (java.io.File. source-uberjar-path) (java.io.File. artifact-uberjar-path))
     (create-script


### PR DESCRIPTION
Ring produces uberjar with the same name so I just added option to disable `uberjar` 
